### PR TITLE
remove references to "token"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+
+testing/

--- a/src/alias.h
+++ b/src/alias.h
@@ -4,14 +4,16 @@
 #include <vector>
 #include <string_view>
 #include <functional>
-#include "libs/token.h"
+// #include "libs/token.h"
 
 
 namespace ws::lexer {
     struct StringIter;
 
-    using Token    = ws::token::Token;
-    using Group    = std::vector<Token>;
+    // using Token    = ws::token::Token;
+
+	template <typename T>
+	using Group    = std::vector<T>;
     using Position = ws::token::Position;
 
 

--- a/src/consumer/consumer.h
+++ b/src/consumer/consumer.h
@@ -14,10 +14,11 @@
 
 namespace ws::lexer {
 
+	template <typename T>
     std::optional<Token> get_next_token(
         const Rules& rules,
         ws::lexer::StringIter& iter,
-        ws::lexer::Group& tokens
+        T& tokens
     ) {
         auto size = tokens.size();
 
@@ -31,20 +32,22 @@ namespace ws::lexer {
     }
 
 
+	template <typename T>
     void consume(
         const Rules& rules,
         ws::lexer::StringIter& iter,
-        ws::lexer::Group& tokens
+        T& tokens
     ) {
         rules.at(iter.peek()) (iter, tokens);
         iter.incr();
     }
 
 
+	template <typename T>
     void lexer(
         const Rules& rules,
         ws::lexer::StringIter& iter,
-        ws::lexer::Group& tokens
+        T& tokens
     ) {
         while (not iter.is_end())
             consume(rules, iter, tokens);


### PR DESCRIPTION
this should make the lexer far more generic capable of being embedded in any other projects